### PR TITLE
fix: 테스트 케이스 검사 정확도 향상

### DIFF
--- a/src/main/resources/code_sample/TestHelper.java
+++ b/src/main/resources/code_sample/TestHelper.java
@@ -47,9 +47,9 @@ public class TestHelper {
         e.printStackTrace();
       }
 
-      String output = outputStream.toString();
+      String output = outputStream.toString().strip();
       System.setOut(printOut);
-      if (output.equals(testCase.expectedOutput)) {
+      if (output.equals(testCase.expectedOutput.strip())) {
         passedCases++;
         continue;
       } else {

--- a/src/main/resources/code_sample/TestHelper.java
+++ b/src/main/resources/code_sample/TestHelper.java
@@ -47,9 +47,9 @@ public class TestHelper {
         e.printStackTrace();
       }
 
-      String output = outputStream.toString().strip();
+      String output = outputStream.toString().stripTrailing();
       System.setOut(printOut);
-      if (output.equals(testCase.expectedOutput.strip())) {
+      if (output.equals(testCase.expectedOutput.stripTrailing())) {
         passedCases++;
         continue;
       } else {


### PR DESCRIPTION
## [버그 신고] TestHelper에서 값이 정확하나 케이스가 실패되는 경우 #30 

## 배경

아래 사진은 이슈가 발생했던 문제 10815에서의 결과입니다.
눈으로 보았을 때 기대 값과 실제 값이 같아 보이나, 테스트가 실패하게 되어 수정하게 되었습니다.

<img width="210" alt="스크린샷 2024-04-09 12 32 53" src="https://github.com/PENEKhun/baekjoon-java-starter/assets/70135292/47e32e8c-ff54-4b19-aaa3-75e2e8146dec">

## 변경점

TestHelper에서 테스트 케이스와 출력 결과에 stripTrailing() 적용

## 설명

```java
// output -> 10815
"""
1 0 0 1 1 0 0 1
"""
```

위의 output은 아래와 완벽하게 같습니다.

```java
"1 0 0 1 1 0 0 1\n"
```

그리고 이슈가 발생했던 제 코드의 일부입니다.

```java
for (int s: second) {
      if (card.containsKey(s)) {
        bw.write("1 ");
      } else {
        bw.write("0 ");
      }
    }
    bw.flush();
    bw.close();
```

이 경우, **올바르게 작성된 코드일 때** output은 아래와 같습니다.

```java
"1 0 0 1 1 0 0 1 "
```

이 때, TestHelper는 ```"1 0 0 1 1 0 0 1\n".equals("1 0 0 1 1 0 0 1")```을 수행하게 되고, 당연하게 False가 나올 수 밖에 없습니다.

단, 여기서 공백을 제거하는 것이 맞느냐, 그렇지 않느냐에 대한 여부는 
해당 프로젝트의 목적인 백준 온라인 저지의 채점 기준으로 정해야 한다고 생각하며, 위 코드의 결과는 AC입니다. 

<img width="691" alt="스크린샷 2024-04-09 12 45 48" src="https://github.com/PENEKhun/baekjoon-java-starter/assets/70135292/4c016077-a8d8-4e15-acff-1e1606f257a4">

백준 온라인 저지에서 출력 결과에 포함되는 공백, 개행 등의 이슈를 살펴보았을 때 (제 개인적인 추측으로)
문자열의 마지막에 포함되는 공백 문자는 자체적으로 처리하는 것으로 보입니다. 

백준 테스트 제출번호: [76636406](https://www.acmicpc.net/source/76636406)

## 테스트 결과

<img width="210" alt="스크린샷 2024-04-09 12 32 53" src="https://github.com/PENEKhun/baekjoon-java-starter/assets/70135292/47e32e8c-ff54-4b19-aaa3-75e2e8146dec">

- [10815] 수정 이전의 TestHelper 출력 결과입니다.

<img width="258" alt="스크린샷 2024-04-09 12 33 42" src="https://github.com/PENEKhun/baekjoon-java-starter/assets/70135292/97cb0307-4057-4e5a-8263-341b027fc785">

- [10815] 수정 이후의 TestHelper 출력 결과입니다.

<img width="250" alt="스크린샷 2024-04-09 13 00 43" src="https://github.com/PENEKhun/baekjoon-java-starter/assets/70135292/39b7ca01-5c5d-44b5-989a-78f287317185">

- [예외 케이스, 2776] 수정 이후의 TestHelper 출력 결과입니다. (해당 케이스는 출력 결과가 여러 줄인 케이스로 문제가 발생했는지 확인.)

+ 백준 1000번 문제로 공백, 개행 등 채점 기준 테스트 완료